### PR TITLE
Make fail and I try to fix

### DIFF
--- a/src/tensorNet.cpp
+++ b/src/tensorNet.cpp
@@ -56,12 +56,12 @@ ICudaEngine* createTrtFromUFF(char* modelpath)
 {
     auto parser = createUffParser();
 
-    parser->registerInput("enc_text", DimsCHW(1, VOC_LEN, 1));
-    parser->registerInput("dec_text", DimsCHW(1, VOC_LEN, 1));
-    parser->registerInput("h0_in", DimsCHW(1, DIM, 1));
-    parser->registerInput("c0_in", DimsCHW(1, DIM, 1));
-    parser->registerInput("h1_in", DimsCHW(1, DIM, 1));
-    parser->registerInput("c1_in", DimsCHW(1, DIM, 1));
+    parser->registerInput("enc_text", DimsCHW(1, VOC_LEN, 1), UffInputOrder::kNCHW);
+    parser->registerInput("dec_text", DimsCHW(1, VOC_LEN, 1), UffInputOrder::kNCHW);
+    parser->registerInput("h0_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
+    parser->registerInput("c0_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
+    parser->registerInput("h1_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
+    parser->registerInput("c1_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
 
     parser->registerOutput("h0_out");
     parser->registerOutput("c0_out");


### PR DESCRIPTION
I try to build your code on the jetson tx2.
But following error happens when I build `make`.

```
src/tensorNet.cpp: In function ‘nvinfer1::ICudaEngine* createTrtFromUFF(char*)’:
src/tensorNet.cpp:59:61: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [9], nvinfer1::DimsCHW)’
     parser->registerInput("enc_text", DimsCHW(1, VOC_LEN, 1));
                                                             ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
src/tensorNet.cpp:60:61: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [9], nvinfer1::DimsCHW)’
     parser->registerInput("dec_text", DimsCHW(1, VOC_LEN, 1));
                                                             ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
src/tensorNet.cpp:61:54: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [6], nvinfer1::DimsCHW)’
     parser->registerInput("h0_in", DimsCHW(1, DIM, 1));
                                                      ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
src/tensorNet.cpp:62:54: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [6], nvinfer1::DimsCHW)’
     parser->registerInput("c0_in", DimsCHW(1, DIM, 1));
                                                      ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
src/tensorNet.cpp:63:54: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [6], nvinfer1::DimsCHW)’
     parser->registerInput("h1_in", DimsCHW(1, DIM, 1));
                                                      ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
src/tensorNet.cpp:64:54: error: no matching function for call to ‘nvuffparser::IUffParser::registerInput(const char [6], nvinfer1::DimsCHW)’
     parser->registerInput("c1_in", DimsCHW(1, DIM, 1));
                                                      ^
In file included from src/tensorNet.cpp:29:0:
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note: candidate: virtual bool nvuffparser::IUffParser::registerInput(const char*, nvinfer1::Dims, nvuffparser::UffInputOrder)
     virtual bool registerInput(const char* inputName, nvinfer1::Dims inputDims, UffInputOrder inputOrder) = 0;
                  ^
/usr/include/aarch64-linux-gnu/NvUffParser.h:182:18: note:   candidate expects 3 arguments, 2 provided
Makefile:28: recipe for target 'all' failed
make: *** [all] Error 1
```

I fix the code because `registerInput` changes.

https://docs.nvidia.com/deeplearning/sdk/tensorrt-api/c_api/classnvuffparser_1_1_i_uff_parser.html#aa88fc7901e6805be9e093dd0b98310e3

- Before

```cpp
    parser->registerInput("enc_text", DimsCHW(1, VOC_LEN, 1));
    parser->registerInput("dec_text", DimsCHW(1, VOC_LEN, 1));
    parser->registerInput("h0_in", DimsCHW(1, DIM, 1));
    parser->registerInput("c0_in", DimsCHW(1, DIM, 1));
    parser->registerInput("h1_in", DimsCHW(1, DIM, 1));
    parser->registerInput("c1_in", DimsCHW(1, DIM, 1));
```

I change the code with reference to this site

https://docs.nvidia.com/deeplearning/sdk/tensorrt-developer-guide/index.html

- After

```cpp
    parser->registerInput("enc_text", DimsCHW(1, VOC_LEN, 1), UffInputOrder::kNCHW);
    parser->registerInput("dec_text", DimsCHW(1, VOC_LEN, 1), UffInputOrder::kNCHW);
    parser->registerInput("h0_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
    parser->registerInput("c0_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
    parser->registerInput("h1_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
    parser->registerInput("c1_in", DimsCHW(1, DIM, 1), UffInputOrder::kNCHW);
```

Do these changes correct?